### PR TITLE
snapshots: adding pacman command line as description

### DIFF
--- a/snapper-pac-post
+++ b/snapper-pac-post
@@ -3,7 +3,7 @@
 PREFILE=/etc/snapper/.snap-pac-pre
 if [ -f $PREFILE ]; then
     SNAPPERPACPRE=$(cat $PREFILE)
-    snapper --config root create --cleanup-algorithm number --type post --pre-number $SNAPPERPACPRE --description "pacman posttransaction"
+    snapper --config root create --cleanup-algorithm number --type post --pre-number $SNAPPERPACPRE --description "$(xargs -0 printf '%s ' < /proc/$PPID/cmdline)"
     rm $PREFILE
 else
     echo "WARNING: $PREFILE does not exist, so not performing post snapshot. If you are initially installing snap-pac, this is normal."

--- a/snapper-pac-pre
+++ b/snapper-pac-pre
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-snapper --config root create --type pre --cleanup-algorithm number --print-number --description "pacman pretransaction" > /etc/snapper/.snap-pac-pre
+snapper --config root create --type pre --cleanup-algorithm number --print-number --description "$(xargs -0 printf '%s ' < /proc/$PPID/cmdline)" > /etc/snapper/.snap-pac-pre


### PR DESCRIPTION
I'd like to get more information from snapshot descriptions. Unfortunatley pacman doesn't give a way to access much data for hooks, but the command line of the executing pacman process should be sufficient most of the times.
### Open questions
- [ ] Is there a more elegant way to gather parent's cmdline?
- [ ] Do we need to gather it twice or save it the same way as pre snapshot numbers?
- [ ] Is pre/post detail in description required? It is already present in the snapshot type field 

What do you think?
