### PR TITLE
Read configuration values from `/etc/snap-pac`

### DIFF
--- a/scripts/snap-pac
+++ b/scripts/snap-pac
@@ -20,8 +20,10 @@
 
 set -o errtrace
 
+[[ -f /etc/snap-pac ]] && [[ -r /etc/snap-pac ]] && source /etc/snap-pac
+
 declare -r SNAPPER_CONFIG_FILE=/etc/conf.d/snapper
-declare -r DESC_LIMIT=48
+declare -r DESC_LIMIT=${DESC_LIMIT:-48}
 declare -r name="snap-pac"
 declare PACMAN_ABORT_ON_FAIL="no"
 declare -r pacman_cmd="$(ps -q $(ps -p "$$" -o ppid=) -o args=)"


### PR DESCRIPTION
This is a quick proposal on how to solve #15.
**I did not (yet) test it.**

The idea is the following:
Test whether `/etc/snap-pac` is a readable file and then source it.
Set `DESC_LIMIT` only to the default value of `48` if it was not specified in the sourced file.