### PR TITLE
Allow to occasionally skip snap-pac run

### DIFF
--- a/scripts/snap-pac
+++ b/scripts/snap-pac
@@ -20,6 +20,8 @@
 
 set -o errtrace
 
+[[ ! -z "$SNAP_PAC_IGNORE" ]] && { echo "snap-pac: skipping..."; exit; }
+
 readonly argv0="snap-pac"
 readonly SNAPPAC_CONFIG_FILE=/etc/snap-pac.conf
 readonly SNAPPER_CONFIG_FILE=/etc/conf.d/snapper

--- a/scripts/snap-pac
+++ b/scripts/snap-pac
@@ -20,7 +20,7 @@
 
 set -o errtrace
 
-[[ ! -z "$SNAP_PAC_IGNORE" ]] && { echo "snap-pac: skipping..."; exit; }
+[[ -n "$SNAP_PAC_SKIP" ]] && { echo "snap-pac: skipping..."; exit 0; }
 
 readonly argv0="snap-pac"
 readonly SNAPPAC_CONFIG_FILE=/etc/snap-pac.conf


### PR DESCRIPTION
Most of the times I want snap-pac to make a snapshot, but sometimes I want to test a package or something like that, and I don't want to create snapshots. 

My most recent personal example is that I was comparing the performance of `python-tensorflow` and `python-tensorflow-cuda`, reinstalling them back and forth, and then I realized that my snapshots are bloated with unnecessary entries.

This PR adds an ability to use `$ SNAP_PAC_SKIP=true sudo pacman -S ...`.

The current code is more of a prototype, please suggest how you'd like to name the option, what to print to stdout and any other ideas - or feel free to take over the PR if that's simpler for you.