### PR TITLE
Update snap_pac.py to Solve the problem that pacman cannot run normal…

### DIFF
--- a/scripts/snap_pac.py
+++ b/scripts/snap_pac.py
@@ -201,3 +201,18 @@ if __name__ == "__main__":
                              data["description"], chroot, pre_number, data["userdata"])()
             logging.info(f"==> {snapper_config}: {num}")
             prefile.write(num)
+
+            # Solve the problem that pacman cannot run normally after rollback due to the pacman lock file in the snapshot.
+            try:
+                # Set the snapshot to read-write mode
+                os.system(f"snapper --config {snapper_config} modify --read-write {num}")
+
+                # Delete the specified file
+                file_path = f"/.snapshots/{num}/snapshot/var/lib/pacman/db.lck"
+                os.system(f"rm -f {file_path}")
+
+                # Restore the snapshot to read-only mode
+                os.system(f"snapper --config {snapper_config} modify --read-only {num}")
+            except Exception as e:
+                logging.error(f"Error modifying snapshot {num}: {e}")
+

--- a/scripts/snap_pac.py
+++ b/scripts/snap_pac.py
@@ -24,6 +24,8 @@ from pathlib import Path
 import os
 import sys
 import tempfile
+import subprocess
+import time
 
 
 logging.basicConfig(format="%(message)s", level=logging.INFO)
@@ -204,15 +206,17 @@ if __name__ == "__main__":
 
             # Solve the problem that pacman cannot run normally after rollback due to the pacman lock file in the snapshot.
             try:
-                # Set the snapshot to read-write mode
-                os.system(f"snapper --config {snapper_config} modify --read-write {num}")
+                time.sleep(0.2)
+                subprocess.run(["btrfs", "property", "set", "-ts", f"/.snapshots/{num}/snapshot", "ro", "false"], check=True)
 
-                # Delete the specified file
-                file_path = f"/.snapshots/{num}/snapshot/var/lib/pacman/db.lck"
-                os.system(f"rm -f {file_path}")
+                lock_file = Path(f"/.snapshots/{num}/snapshot/var/lib/pacman/db.lck")
+                lock_file.unlink() 
 
-                # Restore the snapshot to read-only mode
-                os.system(f"snapper --config {snapper_config} modify --read-only {num}")
+                subprocess.run(["btrfs", "property", "set", "-ts", f"/.snapshots/{num}/snapshot", "ro", "true"], check=True)
+
+            except subprocess.CalledProcessError as e:
+                logging.error(f"Failed to modify snapshot properties: {e}")
             except Exception as e:
-                logging.error(f"Error modifying snapshot {num}: {e}")
+                logging.error(f"Error deleting db.lck: {e}")
+
 

--- a/scripts/snap_pac.py
+++ b/scripts/snap_pac.py
@@ -25,7 +25,6 @@ import os
 import sys
 import tempfile
 import subprocess
-import time
 
 
 logging.basicConfig(format="%(message)s", level=logging.INFO)
@@ -197,26 +196,14 @@ if __name__ == "__main__":
 
         data = config_processor(snapper_config)
         if data["snapshot"]:
+            if os.path.isfile("/var/lib/pacman/db.lck"):
+                subprocess.run("mkdir -p /tmp/snap-pac", shell=True, check=True)
+                subprocess.run("mv /var/lib/pacman/db.lck /tmp/snap-pac/ && sync", shell=True, check=True)
             prefile = Prefile(snapper_config, args.type)
             pre_number = prefile.read()
             num = SnapperCmd(snapper_config, args.type, data["cleanup_algorithm"],
                              data["description"], chroot, pre_number, data["userdata"])()
             logging.info(f"==> {snapper_config}: {num}")
             prefile.write(num)
-
-            # Solve the problem that pacman cannot run normally after rollback due to the pacman lock file in the snapshot.
-            try:
-                time.sleep(0.2)
-                subprocess.run(["btrfs", "property", "set", "-ts", f"/.snapshots/{num}/snapshot", "ro", "false"], check=True)
-
-                lock_file = Path(f"/.snapshots/{num}/snapshot/var/lib/pacman/db.lck")
-                lock_file.unlink() 
-
-                subprocess.run(["btrfs", "property", "set", "-ts", f"/.snapshots/{num}/snapshot", "ro", "true"], check=True)
-
-            except subprocess.CalledProcessError as e:
-                logging.error(f"Failed to modify snapshot properties: {e}")
-            except Exception as e:
-                logging.error(f"Error deleting db.lck: {e}")
-
-
+            if os.path.isfile("/tmp/snap-pac/db.lck"):
+                subprocess.run("mv /tmp/snap-pac/db.lck /var/lib/pacman/ && sync", shell=True, check=True)


### PR DESCRIPTION
…ly after rollback due to the pacman lock file in the snapshot.


I now regularly use [snapper-rollback](https://github.com/jrabinow/snapper-rollback)  with Arch Linux's recommended btrfs setup to elegantly and efficiently restore my system.

However, after rolling back to pre/post snapshots created by snap-pac, pacman stops working. My old solutions don't work with snapper-rollback's elegant approach.

The core problem:
Pacman's lock mechanism doesn't work well with snapshot hooks. The current sequence is:

Pacman locks database 🔒

Pre-snapshot hook runs 📸

Post-snapshot hook runs 📸

Pacman unlocks database 🔓

This works for most hooks, but fails for system snapshots. For snapshots, the ideal sequence should be:

Pre-snapshot hook 📸

Pacman locks 🔒

Pacman unlocks 🔓

Post-snapshot hook 📸

My solution:
By deleting db.lck in snapshots, we achieve the same result as having the ideal sequence. This keeps pacman working after rollbacks while maintaining snapper-rollback's smooth operation.

before:
➜  ~ sudo snapper list
...
19 │ single │       │ Sat 07 Jun 2025 08:04:42 PM │ root │         │ test2                                                                    │
20 │ pre    │       │ Sat 07 Jun 2025 08:04:51 PM │ root │ number  │ pacman -S iperf3                                                         │
21 │ post   │    20 │ Sat 07 Jun 2025 08:04:52 PM │ root │ number  │ iperf3 lksctp-tools                                                      │
22 │ single │       │ Sat 07 Jun 2025 08:04:58 PM │ root │         │ test3                                                                    │
➜  ~ sudo  snapper status 19..20
c..... /home/abc/.zsh_history
+..... /var/lib/pacman/db.lck
➜  ~ sudo  snapper status 21..22
c..... /home/abc/.zsh_history
-..... /var/lib/pacman/db.lck


new:
➜  ~ sudo snapper list
...
26 │ single │       │ Sun 08 Jun 2025 01:17:27 AM │ root │         │ test6                                                                    │
27 │ pre    │       │ Sun 08 Jun 2025 01:17:37 AM │ root │ number  │ pacman -S htop                                                           │
28 │ post   │    27 │ Sun 08 Jun 2025 01:17:37 AM │ root │ number  │ htop                                                                     │
29 │ single │       │ Sun 08 Jun 2025 01:17:55 AM │ root │         │ test7                                                                    │
➜  ~ sudo  snapper status 26..27
c..... /home/abc/.zsh_history
➜  ~ sudo  snapper status 28..29
c..... /home/abc/.zsh_history


my btrfs layout:
  ├── @
  ├── @snapshots
  └── @var_log
  from https://wiki.archlinux.org/title/Snapper

